### PR TITLE
feat(premiums): change unit from d to h starting from 01.01.2025

### DIFF
--- a/backend/bin/automigrate.js
+++ b/backend/bin/automigrate.js
@@ -66,7 +66,7 @@ function run() {
         unit: "d",
         holiday: true,
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -75,7 +75,7 @@ function run() {
         type: "static",
         unit: "d",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -84,7 +84,7 @@ function run() {
         type: "static",
         unit: "d",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -93,7 +93,7 @@ function run() {
         type: "static",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -102,8 +102,23 @@ function run() {
         type: "static",
         unit: "d",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
+          .toDate(),
+        end: moment()
+          .year(2024)
+          .endOf("year")
+          .endOf("day")
+          .toDate()
+      },
+      {
+        label: "Treueprämien",
+        type: "static",
+        unit: "h",
+        start: moment()
+          .year(2025)
+          .startOf("year")
+          .startOf("day")
           .toDate()
       },
       {
@@ -111,7 +126,7 @@ function run() {
         type: "static",
         unit: "n",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -120,7 +135,7 @@ function run() {
         type: "range",
         unit: "r",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -129,7 +144,7 @@ function run() {
         type: "range",
         unit: "r",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -138,7 +153,7 @@ function run() {
         type: "range",
         unit: "r",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -148,7 +163,7 @@ function run() {
         type: "dynamic",
         unit: "l",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate(),
         factor: 2.26
@@ -159,7 +174,7 @@ function run() {
         type: "dynamic",
         unit: "l",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate(),
         factor: 1.58
@@ -170,7 +185,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -180,7 +195,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -190,7 +205,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -200,7 +215,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -211,7 +226,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -221,7 +236,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -231,7 +246,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -241,7 +256,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -251,7 +266,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -261,7 +276,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -271,7 +286,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -281,7 +296,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -291,7 +306,7 @@ function run() {
         type: "dynamic",
         unit: "l",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate(),
         factor: 2.26
@@ -302,7 +317,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },

--- a/backend/bin/database/migrations/change_premiums_unit_from_d_to_h.js
+++ b/backend/bin/database/migrations/change_premiums_unit_from_d_to_h.js
@@ -1,0 +1,77 @@
+const path = require("path");
+const debug = require("debug")("db:migrations");
+const moment = require("moment-timezone");
+
+const app = require(path.resolve(__dirname, "../../../server/server"));
+debug("Loading application...");
+setTimeout(run, 1000 * 10);
+
+function run() {
+  const Element = app.models.element;
+  const ds = app.dataSources.mongoDS;
+
+  Element.findOne(
+    { where: { label: "Treueprämien", unit: "d", end: null } },
+    (err, element) => {
+      if (err) {
+        throw err;
+      }
+
+      if (element) {
+        debug("Running Treueprämien unit change migration");
+        element.updateAttributes(
+          {
+            end: moment()
+              .year(2024)
+              .endOf("year")
+              .endOf("day")
+          },
+          (err, updatedElement) => {
+            if (err) {
+              throw err;
+            }
+            debug(
+              "Treueprämien with unit d successfully ended at end of year 2024"
+            );
+            debug(updatedElement);
+
+            const start = moment()
+              .year(2025)
+              .startOf("year")
+              .startOf("day");
+
+            Element.create(
+              {
+                project: "Default",
+                label: "Treueprämien",
+                type: "static",
+                unit: "h",
+                factor: 1,
+                holiday: false,
+                start,
+                end: null,
+                tooltip: "<p>Keine Informationen vorhanden</p>",
+                maxStart: start
+                  .clone()
+                  .add(4, "years")
+                  .toDate(),
+                deletable: false
+              },
+              (err, newElement) => {
+                if (err) {
+                  throw err;
+                }
+                debug("Treueprämien with unit h successfully created");
+                debug(newElement);
+                ds.disconnect();
+              }
+            );
+          }
+        );
+      } else {
+        debug("Treueprämien migration already applied");
+        ds.disconnect();
+      }
+    }
+  );
+}

--- a/backend/bin/seeddatabase.js
+++ b/backend/bin/seeddatabase.js
@@ -89,7 +89,7 @@ function run() {
         unit: "d",
         holiday: true,
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -98,7 +98,7 @@ function run() {
         type: "static",
         unit: "d",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -107,7 +107,7 @@ function run() {
         type: "static",
         unit: "d",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -116,7 +116,7 @@ function run() {
         type: "static",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -125,8 +125,23 @@ function run() {
         type: "static",
         unit: "d",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
+          .toDate(),
+        end: moment()
+          .year(2024)
+          .endOf("year")
+          .endOf("day")
+          .toDate()
+      },
+      {
+        label: "Treueprämien",
+        type: "static",
+        unit: "h",
+        start: moment()
+          .year(2025)
+          .startOf("year")
+          .startOf("day")
           .toDate()
       },
       {
@@ -134,7 +149,7 @@ function run() {
         type: "static",
         unit: "n",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -143,7 +158,7 @@ function run() {
         type: "range",
         unit: "r",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -152,7 +167,7 @@ function run() {
         type: "range",
         unit: "r",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -161,7 +176,7 @@ function run() {
         type: "range",
         unit: "r",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -171,7 +186,7 @@ function run() {
         type: "dynamic",
         unit: "l",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate(),
         factor: 2.26
@@ -182,7 +197,7 @@ function run() {
         type: "dynamic",
         unit: "l",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate(),
         factor: 1.58
@@ -193,7 +208,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -203,7 +218,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -213,7 +228,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -223,7 +238,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -234,7 +249,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -244,7 +259,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -254,7 +269,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -264,7 +279,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -274,7 +289,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -284,7 +299,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -294,7 +309,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -304,7 +319,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },
@@ -314,7 +329,7 @@ function run() {
         type: "dynamic",
         unit: "l",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate(),
         factor: 2.26
@@ -325,7 +340,7 @@ function run() {
         type: "dynamic",
         unit: "h",
         start: moment()
-          .subtract(2, "years")
+          .year(2018)
           .startOf("year")
           .toDate()
       },

--- a/backend/common/reporting/constants.js
+++ b/backend/common/reporting/constants.js
@@ -18,9 +18,16 @@ const DAY_TO_HOURS_ELEMENTS = [
   "plannedPremiums"
 ];
 
+const DAY_TO_HOURS_ELEMENTS_2025 = [
+  "transferGrantedVacations",
+  "plannedVacations",
+  "plannedMixed"
+];
+
 module.exports = {
   HOURS_PER_DAY,
   DATE_KEY_FORMAT,
   LABEL_TO_PROFILE_LOOKUP,
-  DAY_TO_HOURS_ELEMENTS
+  DAY_TO_HOURS_ELEMENTS,
+  DAY_TO_HOURS_ELEMENTS_2025
 };

--- a/backend/common/reporting/helpers.js
+++ b/backend/common/reporting/helpers.js
@@ -2,7 +2,12 @@ const _ = require("lodash");
 const debug = require("debug")("app:reporting:helpers");
 const moment = require("moment-timezone");
 
-const { DATE_KEY_FORMAT, HOURS_PER_DAY } = require("./constants");
+const {
+  DATE_KEY_FORMAT,
+  HOURS_PER_DAY,
+  DAY_TO_HOURS_ELEMENTS,
+  DAY_TO_HOURS_ELEMENTS_2025
+} = require("./constants");
 const formatters = require("../formatters");
 
 moment.locale("de");
@@ -244,6 +249,10 @@ const employmentLookup = (employments, date) => {
   return scope;
 };
 
+function getHouerlyElements(year) {
+  return year > 2024 ? DAY_TO_HOURS_ELEMENTS_2025 : DAY_TO_HOURS_ELEMENTS;
+}
+
 module.exports = {
   fetchElements,
   fetchProfiles,
@@ -254,5 +263,6 @@ module.exports = {
   calcEmploymentScopes,
   applyEmploymentScopes,
   calcWeekdays,
-  employmentLookup
+  employmentLookup,
+  getHouerlyElements
 };

--- a/frontend/app/containers/SettingsPage/EmploymentTab.js
+++ b/frontend/app/containers/SettingsPage/EmploymentTab.js
@@ -79,7 +79,8 @@ export class EmploymentTab extends React.PureComponent {
   }
 
   renderTab() {
-    const { isClosed, isImpersonated, isTeamleader, profile, employments } = this.props;
+    const { isClosed, isImpersonated, isTeamleader, profile, employments, selectedYear } = this.props;
+    const plannedPremiumsLabel = selectedYear > 2024 ? 'Stunden' : 'Tage';
     const { submitProfile } = this.props;
 
     const employmentRecords = [];
@@ -151,7 +152,7 @@ export class EmploymentTab extends React.PureComponent {
               { key: 'plannedPremiums',
                 boxes: [
                   { width: 4 / 5, label: 'Bezeichnung', value: 'Treueprämien', align: 'left' },
-                  { width: 1 / 5, label: 'Tage', value: profile.plannedPremiums.toString(), align: 'right', name: 'plannedPremiums' },
+                  { width: 1 / 5, label: plannedPremiumsLabel, value: profile.plannedPremiums.toString(), align: 'right', name: 'plannedPremiums' },
                 ],
               },
             ]}
@@ -251,6 +252,7 @@ EmploymentTab.propTypes = {
   }).isRequired,
   employments: PropTypes.array.isRequired,
   record: PropTypes.object.isRequired,
+  selectedYear: PropTypes.number.isRequired,
   // actions
   submitProfile: PropTypes.func.isRequired,
   setComponent: PropTypes.func.isRequired,

--- a/frontend/app/containers/SettingsPage/TableEmployment.js
+++ b/frontend/app/containers/SettingsPage/TableEmployment.js
@@ -4,6 +4,8 @@ import moment from 'moment-timezone';
 
 class EmploymentSettingTable extends React.PureComponent {
   render() {
+    const plannedPremiumsHouerly = this.props.selectedYear > 2024;
+
     const genRows = (sectionIndex) => {
       const rows = [];
 
@@ -72,8 +74,8 @@ class EmploymentSettingTable extends React.PureComponent {
               </tr>
               <tr>
                 <td className={'column-0'}>Treueprämien</td>
-                <td className={'column-1'}>{this.props.profile.plannedPremiums.toFixed(2)}</td>
-                <td className={'column-2'}></td>
+                <td className={'column-1'}>{!plannedPremiumsHouerly ? this.props.profile.plannedPremiums.toFixed(2) : undefined}</td>
+                <td className={'column-2'}>{plannedPremiumsHouerly ? this.props.profile.plannedPremiums.toFixed(2) : undefined}</td>
               </tr>
             </tbody>
           </table>

--- a/frontend/app/containers/SettingsPage/index.js
+++ b/frontend/app/containers/SettingsPage/index.js
@@ -99,7 +99,12 @@ export class SettingsPage extends React.PureComponent {
         rows.push(['Ferien', this.props.Settings.profile.plannedVacations.toFixed(2), null]);
         rows.push(['Militär, Mutterschaft und Diverses', this.props.Settings.profile.plannedMixed.toFixed(2), null]);
         rows.push(['Bewilligte Nachqual.', null, this.props.Settings.profile.plannedQuali.toFixed(2)]);
-        rows.push(['Treueprämien', this.props.Settings.profile.plannedPremiums.toFixed(2), null]);
+
+        if (this.props.Settings.selectedYear > 2024) {
+          rows.push(['Treueprämien', null, this.props.Settings.profile.plannedPremiums.toFixed(2)]);
+        } else {
+          rows.push(['Treueprämien', this.props.Settings.profile.plannedPremiums.toFixed(2), null]);
+        }
 
         rows.push(emptyRow);
         rows.push(['Überträge aus dem Vorjahr', 'Tage', 'Stunden']);
@@ -164,6 +169,7 @@ export class SettingsPage extends React.PureComponent {
         deleteEmployment={this.props.deleteEmployment}
         isImpersonated={this.props.isImpersonated}
         isTeamleader={this.props.isTeamleader}
+        selectedYear={this.props.Settings.selectedYear}
       />
     );
   }


### PR DESCRIPTION
## Übersicht

Ab dem 01.01.2025 ändert sich die Einheit des statischen Elements `Treueprämie` (`plannedPremiums` in der Code-Ebene) von täglich (**d**) auf stündlich (**h**). Die Zeiterfassung und das Reporting müssen diese Änderung berücksichtigen:

- [x] Migrations- und Seed-Skripte anpassen
- [x] Migrationsskript schreiben, um das bestehende Element zum Jahresende 2024 zu beenden und ein neues Element mit der Einheit `h` ab dem 01.01.2025 einzufügen
- [x] Indikator-Reporting anpassen, um diese Änderungen widerzuspiegeln
- [x] Beschäftigungseinstellungen anpassen, um diese Änderungen widerzuspiegeln
- [x] Reporting anpassen, um diese Änderungen widerzuspiegeln
- [x] Zeiterfassung anpassen, um diese Änderungen widerzuspiegeln
- [x] Exporte (pdf / csv) anpassen, um diese Änderungen widerzuspiegeln
